### PR TITLE
sanitize sql

### DIFF
--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -2,6 +2,17 @@ import * as sql from "../sql-builder.ts";
 import { assertEquals } from "./prelude.ts";
 
 Deno.test(
+  "Sanitize identifiers",
+  () => {
+    const statement = sql.selection(sql.makeSelect(
+      'tables"; DROP SCHEMA public CASCADE; -- ',
+      'information_schema";',
+    ), ['column", (SELECT count(*) FROM pg_class) as "injected']);
+    assertEquals(statement.toSql(), 'SELECT "column"", (SELECT count(*) FROM pg_class) as ""injected"  FROM "information_schema"";"."tables""; DROP SCHEMA public CASCADE; -- "');
+  },
+);
+
+Deno.test(
   "Make a select using a schema",
   () => {
     const statement = sql.makeSelect("tables", "information_schema");
@@ -23,8 +34,11 @@ Deno.test(
 Deno.test(
   "INSERT",
   () => {
-    const statement = sql.makeInsert("some_table", { id: undefined, data: 'test' });
-    assertEquals(statement.toSql(), "INSERT INTO some_table  (id, data) VALUES (( DEFAULT ), ('test'))");
+    const statement = sql.makeInsert("some_table", { id: undefined, data: "test" });
+    assertEquals(
+      statement.toSql(),
+      "INSERT INTO some_table  (id, data) VALUES (( DEFAULT ), ('test'))",
+    );
   },
 );
 

--- a/src/sql-builder.ts
+++ b/src/sql-builder.ts
@@ -110,9 +110,9 @@ function makeUpdate(
 ): SqlBuilder {
   const statement: Statement = {
     "type": "update",
-    "table": { "name": table },
+    "table": qualifiedName(table),
     "sets": Object.keys(setValues).map((k) => ({
-      "column": { "name": k },
+      "column": qualifiedName(k),
       "value": {
         "type": "string",
         "value": String(setValues[k]),


### PR DESCRIPTION
The toSql function does not ensure everything is properly escaped.
Since we are going to execute generated SQLs potentially without sending separate parameters everything should be squeeky clean.

- Add some lower level contructors to build qualified names and reference expressions containinng table names. Escape all strings that will be used to build literals and identifiers
- Sanitize update identifiers
