### PR TITLE
aliased columns

### DIFF
--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -9,11 +9,12 @@ Deno.test(
         'tables"; DROP SCHEMA public CASCADE; -- ',
         'information_schema";',
       ),
+      "tables",
       ['column", (SELECT count(*) FROM pg_class) as "injected'],
     );
     assertEquals(
       statement.toSql(),
-      'SELECT "column"", (SELECT count(*) FROM pg_class) as ""injected"  FROM "information_schema"";"."tables""; DROP SCHEMA public CASCADE; -- "',
+      'SELECT tables ."column"", (SELECT count(*) FROM pg_class) as ""injected"  FROM "information_schema"";"."tables""; DROP SCHEMA public CASCADE; -- "',
     );
   },
 );
@@ -31,9 +32,10 @@ Deno.test(
   () => {
     const statement = sql.selection(
       sql.makeSelect("tables", "information_schema"),
+      "tables",
       ["table_name"],
     );
-    assertEquals(statement.toSql(), "SELECT table_name  FROM information_schema.tables");
+    assertEquals(statement.toSql(), "SELECT tables .table_name  FROM information_schema.tables");
   },
 );
 

--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -9,8 +9,8 @@ Deno.test(
         'tables"; DROP SCHEMA public CASCADE; -- ',
         'information_schema";',
       ),
-      "tables",
       ['column", (SELECT count(*) FROM pg_class) as "injected'],
+      "tables",
     );
     assertEquals(
       statement.toSql(),
@@ -32,12 +32,25 @@ Deno.test(
   () => {
     const statement = sql.selection(
       sql.makeSelect("tables", "information_schema"),
-      "tables",
       ["table_name"],
+      "tables",
     );
     assertEquals(statement.toSql(), "SELECT tables .table_name  FROM information_schema.tables");
   },
 );
+
+Deno.test(
+  "Select columns using alias",
+  () => {
+    const statement = sql.selection(
+      sql.makeSelect("tables", "information_schema"),
+      [["table_name", "name"]],
+      "tables",
+    );
+    assertEquals(statement.toSql(), "SELECT tables .table_name AS name  FROM information_schema.tables");
+  },
+);
+
 
 Deno.test(
   "Sanitize UPDATE identifiers and values",


### PR DESCRIPTION
## Purpose

Allow users to build SELECTs aliasing columns.

- Add table parameter to call selection so we can qualify column names. Allow the use of alias when building selected column
- Keep backwards compatible signature so we can publish without breaking typed statements
