### PR TITLE
Statement builder

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.8",
+  "version": "0.0.9",
   "tasks": {
     "test": "deno test --allow-env --allow-net --allow-read --unstable src",
     "build": "deno bundle src/index.ts dist/index.min.js",
@@ -7,7 +7,7 @@
     "install": "deno task build-cli && cp ./dist/pasta $HOME/.local/bin/",
     "cli": "deno run --allow-env --allow-net --unstable src/cli.ts",
     "prepublishOnly": "npm run build",
-    "build-npm": "deno run -A scripts/build-npm.ts",
+    "build-npm": "deno run -A scripts/build-npm.ts && cd npm && npm pack",
     "update-schema": "deno task build-cli && ./dist/pasta postgres://localhost/pasta_test"
   },
   "fmt": {

--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -1,3 +1,4 @@
+import { uuid } from "../database/pg-catalog.ts";
 import * as sql from "../sql-builder.ts";
 import { assertEquals } from "./prelude.ts";
 
@@ -104,6 +105,17 @@ Deno.test(
     assertEquals(
       statement.toSql(),
       "INSERT INTO some_table  (id, data, nullable) VALUES (( DEFAULT ), ('test'), (null))",
+    );
+  },
+);
+
+Deno.test(
+  "INSERT json values and function calls in the database",
+  () => {
+    const statement = sql.makeInsert("some_table", { id: uuid(), tags: ["some value'; inject --"]});
+    assertEquals(
+      statement.toSql(),
+      "INSERT INTO some_table  (id, tags) VALUES ((gen_random_uuid () ), ('[\"some value''; inject --\"]'))",
     );
   },
 );

--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -100,10 +100,10 @@ Deno.test(
 Deno.test(
   "INSERT",
   () => {
-    const statement = sql.makeInsert("some_table", { id: undefined, data: "test" });
+    const statement = sql.makeInsert("some_table", { id: undefined, data: "test", nullable: null });
     assertEquals(
       statement.toSql(),
-      "INSERT INTO some_table  (id, data) VALUES (( DEFAULT ), ('test'))",
+      "INSERT INTO some_table  (id, data, nullable) VALUES (( DEFAULT ), ('test'), (null))",
     );
   },
 );

--- a/src/__tests__/sql-builder.test.ts
+++ b/src/__tests__/sql-builder.test.ts
@@ -78,10 +78,10 @@ Deno.test(
 Deno.test(
   "UPDATE",
   () => {
-    const statement = sql.makeUpdate("some_table", { id: 1, compositeKey: 2 }, { data: "test" });
+    const statement = sql.makeUpdate("some_table", { id: 1, compositeKey: 2 }, { data: "test", nullable: null, optional: undefined });
     assertEquals(
       statement.toSql(),
-      "UPDATE some_table   SET data = ('test')  WHERE ((id, \"compositeKey\") = (('1'), ('2')))",
+      "UPDATE some_table   SET data = ('test') , nullable = (null)  WHERE ((id, \"compositeKey\") = (('1'), ('2')))",
     );
   },
 );

--- a/src/__tests__/statement-builder.test.ts
+++ b/src/__tests__/statement-builder.test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "./prelude.ts";
 Deno.test(
   "Select columns with order",
   () => {
-    const stmt =  sql.makeSelect("tables", "information_schema").selection(['table_name'], 'tables').order([['t', 'ASC']])
+    const stmt =  sql.makeSelect("tables", "information_schema").columns(['table_name'], 'tables').order([['t', 'ASC']])
     assertEquals(stmt.toSql(), "SELECT tables .table_name  FROM information_schema.tables    ORDER BY t ASC");
   },
 );

--- a/src/__tests__/statement-builder.test.ts
+++ b/src/__tests__/statement-builder.test.ts
@@ -1,0 +1,49 @@
+import * as sql from "../statement-builder.ts";
+import { assertEquals } from "./prelude.ts";
+
+Deno.test(
+  "Select columns with order",
+  () => {
+    const stmt =  sql.makeSelect("tables", "information_schema").selection(['table_name'], 'tables').order([['t', 'ASC']])
+    assertEquals(stmt.toSql(), "SELECT tables .table_name  FROM information_schema.tables    ORDER BY t ASC");
+  },
+);
+
+
+Deno.test(
+  "UPDATE",
+  () => {
+    const statement = sql.makeUpdate("some_table", { id: 1, compositeKey: 2 }, { data: "test" }).returning(['id']);
+    assertEquals(
+      statement.toSql(),
+      "UPDATE some_table   SET data = ('test')  WHERE ((id, \"compositeKey\") = (('1'), ('2')))  RETURNING id",
+    );
+  },
+);
+
+Deno.test(
+  "DELETE",
+  () => {
+    const statement = sql.makeDelete("some_table", { id: 1 }).returning(['id']);
+    assertEquals(statement.toSql(), "DELETE FROM some_table   WHERE ((id) = (('1'))) RETURNING id");
+  },
+);
+
+Deno.test(
+  "UPSERT",
+  () => {
+    const statement = sql.makeUpsert("some_table", { id: 1, updated: false }, { updated: true }).returning(['id']);
+    assertEquals(statement.toSql(), "INSERT INTO some_table  (id, updated) VALUES (('1'), ('false')) ON CONFLICT  DO UPDATE SET updated = ('true')   RETURNING id");
+  },
+);
+
+Deno.test(
+  "INSERT",
+  () => {
+    const statement = sql.makeInsert("some_table", { id: undefined, data: "test" }).returning(['id']);
+    assertEquals(
+      statement.toSql(),
+      "INSERT INTO some_table  (id, data) VALUES (( DEFAULT ), ('test'))  RETURNING id",
+    );
+  },
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * as extractor from "./schema-extractor.ts";
 export * as generators from "./static-modules-generator.ts";
 export * as db from "./transaction.ts";
-export * as sql from "./sql-builder.ts";
+export * as sql from "./statement-builder.ts";

--- a/src/sql-builder.ts
+++ b/src/sql-builder.ts
@@ -123,9 +123,9 @@ function makeUpdate(
   const statement: Statement = {
     "type": "update",
     "table": qualifiedName(table),
-    "sets": Object.keys(setValues).map((k) => ({
+    "sets": Object.keys(setValues).filter((k) => setValues[k] !== undefined).map((k) => ({
       "column": qualifiedName(k),
-      "value": {
+      "value": setValues[k] === null ? { type: "null" } : {
         "type": "string",
         "value": String(setValues[k]),
       },

--- a/src/sql-builder.ts
+++ b/src/sql-builder.ts
@@ -43,6 +43,22 @@ function returning(builder: SqlBuilder, columns: string[]): SqlBuilder {
           };
         }
       },
+      update: (t) => {
+        return {
+          ...t,
+          returning: columnNames.map((c) => ({
+            expr: { type: "ref", name: c },
+          })),
+        };
+      },
+      delete: (t) => {
+        return {
+          ...t,
+          returning: columnNames.map((c) => ({
+            expr: { type: "ref", name: c },
+          })),
+        };
+      },
       insert: (t) => {
         if (t.insert) {
           return {
@@ -171,22 +187,22 @@ function makeSelect(table: string, schema?: string): SqlBuilder {
 
 function order(
   builder: SqlBuilder,
-  columns: string[] | [string, 'ASC' | 'DESC'][],
+  columns: string[] | [string, "ASC" | "DESC"][],
   table?: string,
 ): SqlBuilder {
   const returningMapper = (columnNames: typeof columns) =>
     astMapper((_map) => ({
       selection: (s) => {
-        const orderBy = columnNames.map((c) => table
+        const orderBy = columnNames.map((c) =>
+          table
             ? { by: exprRef(c[0]), order: c[1] }
             : c instanceof Array
-              ? { by: exprRef(c[0]), order: c[1] }
-              : { by: exprRef(c), order: 'ASC'}
-
-        ) as OrderByStatement[]
+            ? { by: exprRef(c[0]), order: c[1] }
+            : { by: exprRef(c), order: "ASC" }
+        ) as OrderByStatement[];
         return ({
           ...s,
-          orderBy
+          orderBy,
         });
       },
     }));
@@ -396,9 +412,9 @@ export {
   makeSelect,
   makeUpdate,
   makeUpsert,
+  order,
   returning,
   selection,
   where,
-  order
 };
 export type { SqlBuilder };

--- a/src/sql-builder.ts
+++ b/src/sql-builder.ts
@@ -250,7 +250,8 @@ function jsToSqlLiteral(value: unknown): Expr {
     ? { type: "default" }
     : value === null
     ? { type: "null" }
-    : { value: String(value), type: "string" };
+    : typeof value === "object" && "returnType" in value ? (value as unknown as Expr)
+    : { value: JSON.stringify(value), type: "string" };
 }
 
 function makeInsert(

--- a/src/sql-builder.ts
+++ b/src/sql-builder.ts
@@ -263,7 +263,9 @@ function makeInsert(
       ? value
       : value === undefined
       ? { type: "default" }
-      : { value: JSON.stringify(value), type: "string" })
+      : value === null
+      ? { type: "null" }
+      : { value: escapeLiteral(String(value)), type: "string" })
     ),
   ] as Expr[][];
   const statement: InsertStatement = {

--- a/src/statement-builder.ts
+++ b/src/statement-builder.ts
@@ -3,14 +3,14 @@ import * as sql from "./sql-builder.ts";
 type SqlBuilder = sql.SqlBuilder
 
 type SelectBuilder = SqlBuilder & {
-  selection: (columns: Parameters<typeof sql.selection>[1], table?: string) => SelectBuilder 
+  columns: (columns: Parameters<typeof sql.selection>[1], table?: string) => SelectBuilder 
   order: (columns: Parameters<typeof sql.order>[1], table?: string) => SelectBuilder 
   where: (columns: Parameters<typeof sql.where>[1]) => SelectBuilder 
 }
 
 function makeSelect(table: string, schema?: string): SelectBuilder {
   const builder = sql.makeSelect(table, schema) as SelectBuilder
-  const selection = (columns: Parameters<typeof sql.selection>[1], table?: string) => {
+  const columns = (columns: Parameters<typeof sql.selection>[1], table?: string) => {
     const { statement, toSql } = sql.selection(builder, columns, table)
     builder.statement = statement
     builder.toSql = toSql
@@ -28,7 +28,7 @@ function makeSelect(table: string, schema?: string): SelectBuilder {
     builder.toSql = toSql
     return builder
   }
-  builder.selection = selection
+  builder.columns = columns
   builder.order = order
   builder.where = where
   return builder

--- a/src/statement-builder.ts
+++ b/src/statement-builder.ts
@@ -1,6 +1,8 @@
 import * as sql from "./sql-builder.ts";
 
-type SelectBuilder = sql.SqlBuilder & {
+type SqlBuilder = sql.SqlBuilder
+
+type SelectBuilder = SqlBuilder & {
   selection: (columns: Parameters<typeof sql.selection>[1], table?: string) => SelectBuilder 
   order: (columns: Parameters<typeof sql.order>[1], table?: string) => SelectBuilder 
   where: (columns: Parameters<typeof sql.where>[1]) => SelectBuilder 
@@ -102,3 +104,4 @@ function makeUpsert(
 }
 
 export { makeSelect, makeInsert, makeUpdate, makeDelete, makeUpsert }
+export type { SqlBuilder, SelectBuilder, InsertBuilder, UpdateBuilder, DeleteBuilder, UpsertBuilder }

--- a/src/statement-builder.ts
+++ b/src/statement-builder.ts
@@ -1,0 +1,104 @@
+import * as sql from "./sql-builder.ts";
+
+type SelectBuilder = sql.SqlBuilder & {
+  selection: (columns: Parameters<typeof sql.selection>[1], table?: string) => SelectBuilder 
+  order: (columns: Parameters<typeof sql.order>[1], table?: string) => SelectBuilder 
+  where: (columns: Parameters<typeof sql.where>[1]) => SelectBuilder 
+}
+
+function makeSelect(table: string, schema?: string): SelectBuilder {
+  const builder = sql.makeSelect(table, schema) as SelectBuilder
+  const selection = (columns: Parameters<typeof sql.selection>[1], table?: string) => {
+    const { statement, toSql } = sql.selection(builder, columns, table)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  const order = (columns: Parameters<typeof sql.order>[1], table?: string) => {
+    const { statement, toSql } = sql.order(builder, columns, table)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  const where = (columns: Parameters<typeof sql.where>[1]) => {
+    const { statement, toSql } = sql.where(builder, columns)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  builder.selection = selection
+  builder.order = order
+  builder.where = where
+  return builder
+}
+
+type InsertBuilder = sql.SqlBuilder & {
+  returning: (columns: Parameters<typeof sql.returning>[1]) => InsertBuilder
+}
+type UpdateBuilder = InsertBuilder
+type UpsertBuilder = InsertBuilder
+type DeleteBuilder = InsertBuilder
+
+function makeInsert(
+  table: string,
+  valueMap: Record<string, unknown>,
+): InsertBuilder {
+  const builder = sql.makeInsert(table, valueMap) as InsertBuilder
+  const returning = (columns: Parameters<typeof sql.returning>[1]) => {
+    const { statement, toSql } = sql.returning(builder, columns)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  builder.returning = returning
+  return builder
+}
+
+function makeUpdate(
+  table: string,
+  keyValues: Record<string, unknown>,
+  setValues: Record<string, unknown>,
+): UpdateBuilder {
+  const builder = sql.makeUpdate(table, keyValues, setValues) as UpdateBuilder
+  const returning = (columns: Parameters<typeof sql.returning>[1]) => {
+    const { statement, toSql } = sql.returning(builder, columns)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  builder.returning = returning
+  return builder
+}
+
+function makeDelete(
+  table: string,
+  keyValues: Record<string, unknown>,
+): DeleteBuilder {
+  const builder = sql.makeDelete(table, keyValues) as DeleteBuilder
+  const returning = (columns: Parameters<typeof sql.returning>[1]) => {
+    const { statement, toSql } = sql.returning(builder, columns)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  builder.returning = returning
+  return builder
+}
+
+function makeUpsert(
+  table: string,
+  insertValues: Record<string, unknown>,
+  updateValues?: Record<string, unknown>,
+): UpsertBuilder {
+  const builder = sql.makeUpsert(table, insertValues, updateValues) as UpsertBuilder
+  const returning = (columns: Parameters<typeof sql.returning>[1]) => {
+    const { statement, toSql } = sql.returning(builder, columns)
+    builder.statement = statement
+    builder.toSql = toSql
+    return builder
+  }
+  builder.returning = returning
+  return builder
+}
+
+export { makeSelect, makeInsert, makeUpdate, makeDelete, makeUpsert }


### PR DESCRIPTION
Create a new API that uses method chaining to build Statements without having database schema types.
This API builds on top of the same funcional base as the typed statements one.
The funcional API in `sql-builder` will be kept hidden so we have a more flexible internal API